### PR TITLE
KelpPlayer#isInWater + KelpPlayer#isInCobweb

### DIFF
--- a/core/src/main/java/de/pxav/kelp/core/player/KelpPlayer.java
+++ b/core/src/main/java/de/pxav/kelp/core/player/KelpPlayer.java
@@ -92,7 +92,6 @@ public class KelpPlayer {
     return this;
   }
 
-
   public KelpPlayer sendActionbar(String message) {
     playerVersionTemplate.sendActionBar(bukkitPlayer, message);
     return this;
@@ -114,5 +113,13 @@ public class KelpPlayer {
 
   public Player getBukkitPlayer() {
     return bukkitPlayer;
+  }
+
+  public boolean isInWater() {
+    return playerVersionTemplate.isInWater(bukkitPlayer);
+  }
+
+  public boolean isInCobweb() {
+    return playerVersionTemplate.isInCobweb(bukkitPlayer);
   }
 }

--- a/core/src/main/java/de/pxav/kelp/core/player/PlayerVersionTemplate.java
+++ b/core/src/main/java/de/pxav/kelp/core/player/PlayerVersionTemplate.java
@@ -31,4 +31,7 @@ public abstract class PlayerVersionTemplate {
 
   public abstract void teleport(Player player, Location location);
 
+  public abstract boolean isInCobweb(Player player);
+
+  public abstract boolean isInWater(Player player);
 }

--- a/v1_8_implementation/src/main/java/de/pxav/kelp/implementation1_8/player/VersionedPlayer.java
+++ b/v1_8_implementation/src/main/java/de/pxav/kelp/implementation1_8/player/VersionedPlayer.java
@@ -8,6 +8,7 @@ import de.pxav.kelp.core.version.Versioned;
 import net.minecraft.server.v1_8_R3.*;
 import org.bukkit.Location;
 import org.bukkit.Sound;
+import org.bukkit.craftbukkit.v1_8_R3.entity.CraftEntity;
 import org.bukkit.craftbukkit.v1_8_R3.entity.CraftPlayer;
 import org.bukkit.entity.Player;
 
@@ -97,6 +98,36 @@ public class VersionedPlayer extends PlayerVersionTemplate {
   @Override
   public Location getLocation(Player player) {
     return null;
+  }
+
+  @Override
+  public boolean isInWater(Player player) {
+    try {
+      Field inWaterField = Entity.class.getDeclaredField("inWater");
+
+      inWaterField.setAccessible(true);
+
+      return inWaterField.getBoolean(((CraftEntity) player).getHandle());
+    } catch (IllegalAccessException | NoSuchFieldException e) {
+      e.printStackTrace();
+    }
+
+    return false;
+  }
+
+  @Override
+  public boolean isInCobweb(Player player) {
+    try {
+      Field hField = Entity.class.getDeclaredField("H");
+
+      hField.setAccessible(true);
+
+      return hField.getBoolean(((CraftEntity) player).getHandle());
+    } catch (IllegalAccessException | NoSuchFieldException e) {
+      e.printStackTrace();
+    }
+
+    return false;
   }
 
   private void sendPacket(Packet packet, Player player) {


### PR DESCRIPTION
Normally, people would check stuff like this by comparing the block the player is standing in, but that's not accurate! NMS provides two booleans which use AABB to detect water or cobwebs. But since they are not easy to reach and many people don't know about them, I figured I could provide these methods.