### PR TITLE
Use File#getParentFile to access parent folder

### DIFF
--- a/core/src/main/java/de/pxav/kelp/core/common/KelpFileUtils.java
+++ b/core/src/main/java/de/pxav/kelp/core/common/KelpFileUtils.java
@@ -25,7 +25,8 @@ public class KelpFileUtils {
   public boolean createIfNotExists(File file) {
     if (file.exists()) return false;
 
-    File directory = new File(file.getPath().replace("/" + file.getName(), ""));
+    File directory = file.getParentFile();
+
     if (!directory.exists()) {
       directory.mkdirs();
     }


### PR DESCRIPTION
I tried launching kelp-core, but it kept failing because it created folders instead of files. Here is the fix.