### PR TITLE
Prepare repository for Maven Central deployment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,18 +31,13 @@ The headlines with `MR <number>` stand for the major release. The following head
 * Fixed bug that CPU load was on 100% when `AnimatedInventory` was opened.
 * Fixed NPE when trying to get item tags of items with type `AIR`
 
-#### v0.0.3 (15.08.2020)
+#### v0.0.3 (12.09.2020)
 * **The particle engine update**
 
-**NEW:** 
+* Kelp can now be referenced through a build tool like Maven or Gradle as it is now part of the Maven Central Repository.
 * Create `ParticleType` class that maps particle type names across different versions.
 * Create version template `ParticleVersionTemplate` and a v1.8 implementation for version independent particle spawning
 * Create particle effect system to spawn complex particle effects.
-
-**FIXED:**
 * If you request a `ScheduledExecutorService` in a constructor annotated with `@Inject` by Guice, a new scheduled thread pool will be injected automatically.
-
-**NOTES**:
-This release only creates a basis of the particle system for kelp. More particle types and effects will follow in the next releases. If you have ideas for more particle effects, feel free to create an own particle effect class and open a PR for it.
 
 

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ playerConnection.sendPacket(spawnPacket);
 
 
 
-### Feature overview
+## Feature overview
 
 - **Sidebar system:** Create sidebars - no matter if animated or just simple & casual. Use up to 32 chars per line and enjoy flicker-free updating
 - **Inventory system:** Create stunning GUIs with minimal effort, use an integrated listener system and meet helpful pre-defined or custom widgets. Never mess with changed material names anymore.
@@ -94,7 +94,12 @@ playerConnection.sendPacket(spawnPacket);
 
 
 
-### Support
+## Support & Requirements
+
+The following requirements are needed:
+* Java 8 or higher
+* A server with Linux/Windows (MacOS has not been tested sufficiently yet)
+* A spigot/paper server with one of the supported versions
 
 There are version implementations for the following version implementations available:
 
@@ -110,7 +115,24 @@ There are version implementations for the following version implementations avai
 | 1.14           | ❌         | Work in progress                                             |
 | 1.15           | ❌         | Following soon                                               |
 
+## Downloading
 
+#### Maven
+```xml
+<dependency>
+  <groupId>com.github.pxav.kelp</groupId>
+  <artifactId>core</artifactId>
+  <version>0.0.3</version>
+</dependency>
+```
+
+### Gradle
+```shell script
+implementation 'com.github.pxav.kelp:core:0.0.3'
+```
+
+### Pre-built files
+If you are a server owner who simply needs the jar files or a developer who does not use a built tool like Maven, you can simply download the pre-built jar files from the [Releaes page](https://github.com/PXAV/kelp/releases). There you can find all versions, but it's recommended to use the latest.
 
 ### Build from source
 
@@ -132,21 +154,13 @@ mvn install
 
 
 
-### How to use
-
-#### For server owners
-
-Put the jar file of the core module into the normal `plugins` folder of your server. Start the server and wait until Kelp has generated the required folders. Pick the right version module for your server and drag it into the `kelp_versions` folder. Reload/Restart the server and Kelp should be ready to use. **Note:** Plugins based on Kelp go into the `kelp_plugins` folder!
-
-
-
-#### For developers
+## How to use
 
 Check out the [KelpWiki](https://github.com/PXAV/kelp/wiki), where you can find tutorials about the different features of Kelp. It is not 100% complete but constantly updated. Furthermore most of the classes and methods have JavaDocs, so check them out. A separate JavaDoc page is following soon. 
 
 
 
-### Contributing
+## Contributing
 
 Currently Kelp is developed by a single developer and bug reports, feature suggestions and pull requests are very welcome. If you want to contribute to the code, have a look at our [contribution guidelines](CONTRIBUTING.md). If you have bug reports, ideas, or need support feel free to open a new issue here on GitHub. 
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 > Developed by pxav (c) 2019-2020
 
-![GitHub release (latest by date including pre-releases)](https://img.shields.io/github/v/release/PXAV/kelp?include_prereleases&label=version) ![GitHub issues](https://img.shields.io/github/issues/PXAV/finate-studio-java) ![GitHub pull requests](https://img.shields.io/github/issues-pr/PXAV/kelp) ![GitHub closed pull requests](https://img.shields.io/github/issues-pr-closed/PXAV/kelp) ![Development Indicator](https://img.shields.io/badge/development-active-brightgreen)
+![GitHub release (latest by date including pre-releases)](https://img.shields.io/github/v/release/PXAV/kelp?include_prereleases&label=version) ![GitHub issues](https://img.shields.io/github/issues/PXAV/kelp) ![GitHub pull requests](https://img.shields.io/github/issues-pr/PXAV/kelp) ![GitHub closed pull requests](https://img.shields.io/github/issues-pr-closed/PXAV/kelp) ![Development Indicator](https://img.shields.io/badge/development-active-brightgreen)
 
 
 

--- a/README.md
+++ b/README.md
@@ -131,6 +131,15 @@ There are version implementations for the following version implementations avai
 implementation 'com.github.pxav.kelp:core:0.0.3'
 ```
 
+### Bazel
+```shell script
+maven_jar(
+    name = "core",
+    artifact = "com.github.pxav.kelp:core:0.0.3",
+    sha1 = "4743f29c20f3b033de5fe8c1eddb374511fa31d8",
+)
+```
+
 ### Pre-built files
 If you are a server owner who simply needs the jar files or a developer who does not use a built tool like Maven, you can simply download the pre-built jar files from the [Releaes page](https://github.com/PXAV/kelp/releases). There you can find all versions, but it's recommended to use the latest.
 

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -3,7 +3,7 @@
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <parent>
-    <groupId>de.pxav.kelp</groupId>
+    <groupId>com.github.pxav.kelp</groupId>
     <artifactId>parent</artifactId>
     <version>0.0.3</version>
   </parent>
@@ -19,11 +19,69 @@
     </repository>
   </repositories>
 
+  <profiles>
+    <profile>
+      <id>central-deploy</id>
+      <activation>
+        <activeByDefault>false</activeByDefault>
+      </activation>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-source-plugin</artifactId>
+            <version>2.2.1</version>
+            <executions>
+              <execution>
+                <id>attach-sources</id>
+                <goals>
+                  <goal>jar-no-fork</goal>
+                </goals>
+              </execution>
+            </executions>
+          </plugin>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-javadoc-plugin</artifactId>
+            <version>2.9.1</version>
+            <executions>
+              <execution>
+                <id>attach-javadocs</id>
+                <goals>
+                  <goal>jar</goal>
+                </goals>
+              </execution>
+            </executions>
+          </plugin>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-gpg-plugin</artifactId>
+            <version>1.5</version>
+            <executions>
+              <execution>
+                <id>sign-artifacts</id>
+                <phase>verify</phase>
+                <goals>
+                  <goal>sign</goal>
+                </goals>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+  </profiles>
+
   <build>
     <plugins>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
+        <version>3.8.1</version>
+        <configuration>
+          <source>8</source>
+          <target>8</target>
+        </configuration>
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>de.pxav.kelp</groupId>
     <artifactId>parent</artifactId>
-    <version>0.0.3-SNAPSHOT</version>
+    <version>0.0.3</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/core/src/main/java/de/pxav/kelp/core/KelpPlugin.java
+++ b/core/src/main/java/de/pxav/kelp/core/KelpPlugin.java
@@ -34,7 +34,7 @@ import java.util.logging.Level;
  *
  * @author pxav
  */
-@Plugin(name = "Kelp", version = "0.0.3-SNAPSHOT")
+@Plugin(name = "Kelp", version = "0.0.3")
 @Author("pxav")
 @Description("A cross version spigot framework.")
 @Singleton

--- a/pom.xml
+++ b/pom.xml
@@ -4,10 +4,50 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
-  <groupId>de.pxav.kelp</groupId>
+  <groupId>com.github.pxav.kelp</groupId>
   <artifactId>parent</artifactId>
   <packaging>pom</packaging>
   <version>0.0.3</version>
+
+  <name>Kelp</name>
+  <description>A cross-version spigot framework to avoid boilerplate code and make your plugin compatible with multiple spigot versions easily</description>
+  <url>https://www.github.com/PXAV/kelp</url>
+
+  <licenses>
+    <license>
+      <name>MIT License</name>
+      <url>http://www.opensource.org/licenses/mit-license.php</url>
+    </license>
+  </licenses>
+
+  <developers>
+    <developer>
+      <name>PXAV</name>
+      <organization>com.github.pxav</organization>
+      <organizationUrl>https://www.github.com/PXAV</organizationUrl>
+    </developer>
+    <developer>
+      <name>Etrayed</name>
+      <organization>com.github.etrayed</organization>
+      <organizationUrl>https://www.github.com/Etrayed</organizationUrl>
+    </developer>
+    <developer>
+      <name>Paul</name>
+      <organization>com.github.paul2708</organization>
+      <organizationUrl>https://www.github.com/Paul2708</organizationUrl>
+    </developer>
+    <developer>
+      <name>Shatuxy</name>
+      <organization>com.github.shatuxy</organization>
+      <organizationUrl>https://www.github.com/Shatuxy</organizationUrl>
+    </developer>
+  </developers>
+
+  <scm>
+    <connection>scm:git:git://github.com/PXAV/kelp.git</connection>
+    <developerConnection>scm:git:ssh://github.com:PXAV/kelp.git</developerConnection>
+    <url>http://github.com/PXAV/kelp/tree/master</url>
+  </scm>
 
   <modules>
     <module>core</module>
@@ -30,9 +70,31 @@
     </dependencies>
   </dependencyManagement>
 
+  <distributionManagement>
+    <snapshotRepository>
+      <id>ossrh</id>
+      <url>https://oss.sonatype.org/content/repositories/snapshots</url>
+    </snapshotRepository>
+    <repository>
+      <id>ossrh</id>
+      <url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
+    </repository>
+  </distributionManagement>
+
   <build>
     <pluginManagement>
       <plugins>
+        <plugin>
+          <groupId>org.sonatype.plugins</groupId>
+          <artifactId>nexus-staging-maven-plugin</artifactId>
+          <version>1.6.7</version>
+          <extensions>true</extensions>
+          <configuration>
+            <serverId>ossrh</serverId>
+            <nexusUrl>https://oss.sonatype.org/</nexusUrl>
+            <autoReleaseAfterClose>true</autoReleaseAfterClose>
+          </configuration>
+        </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-shade-plugin</artifactId>
@@ -63,13 +125,71 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-compiler-plugin</artifactId>
+          <version>3.8.1</version>
           <configuration>
             <source>8</source>
             <target>8</target>
           </configuration>
         </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-source-plugin</artifactId>
+          <version>2.2.1</version>
+          <executions>
+            <execution>
+              <id>attach-sources</id>
+              <goals>
+                <goal>jar-no-fork</goal>
+              </goals>
+            </execution>
+          </executions>
+        </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-javadoc-plugin</artifactId>
+          <version>2.9.1</version>
+          <executions>
+            <execution>
+              <id>attach-javadocs</id>
+              <goals>
+                <goal>jar</goal>
+              </goals>
+            </execution>
+          </executions>
+        </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-gpg-plugin</artifactId>
+          <version>1.5</version>
+          <executions>
+            <execution>
+              <id>sign-artifacts</id>
+              <phase>install</phase>
+              <goals>
+                <goal>sign</goal>
+              </goals>
+            </execution>
+          </executions>
+        </plugin>
       </plugins>
     </pluginManagement>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-gpg-plugin</artifactId>
+        <version>1.5</version>
+        <executions>
+          <execution>
+            <id>sign-artifacts</id>
+            <phase>install</phase>
+            <goals>
+              <goal>sign</goal>
+            </goals>
+          </execution>
+        </executions>
+        <inherited>false</inherited>
+      </plugin>
+    </plugins>
   </build>
 
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
   <groupId>de.pxav.kelp</groupId>
   <artifactId>parent</artifactId>
   <packaging>pom</packaging>
-  <version>0.0.3-SNAPSHOT</version>
+  <version>0.0.3</version>
 
   <modules>
     <module>core</module>

--- a/pom.xml
+++ b/pom.xml
@@ -81,20 +81,98 @@
     </repository>
   </distributionManagement>
 
+
+  <profiles>
+      <!-- This plugin is only used when a deployment to the Maven Central Repo is done.
+     But only project administrators have the authorization to execute deployments.
+     It can be activated by using mvn <goal> -P central-deploy
+     -->
+    <profile>
+      <id>central-deploy</id>
+      <activation>
+        <activeByDefault>false</activeByDefault>
+      </activation>
+      <build>
+        <pluginManagement>
+          <plugins>
+            <plugin>
+              <groupId>org.sonatype.plugins</groupId>
+              <artifactId>nexus-staging-maven-plugin</artifactId>
+              <version>1.6.7</version>
+              <extensions>true</extensions>
+              <configuration>
+                <serverId>ossrh</serverId>
+                <nexusUrl>https://oss.sonatype.org/</nexusUrl>
+                <autoReleaseAfterClose>true</autoReleaseAfterClose>
+              </configuration>
+            </plugin>
+            <plugin>
+              <groupId>org.apache.maven.plugins</groupId>
+              <artifactId>maven-source-plugin</artifactId>
+              <version>2.2.1</version>
+              <executions>
+                <execution>
+                  <id>attach-sources</id>
+                  <goals>
+                    <goal>jar-no-fork</goal>
+                  </goals>
+                </execution>
+              </executions>
+            </plugin>
+            <plugin>
+              <groupId>org.apache.maven.plugins</groupId>
+              <artifactId>maven-javadoc-plugin</artifactId>
+              <version>2.9.1</version>
+              <executions>
+                <execution>
+                  <id>attach-javadocs</id>
+                  <goals>
+                    <goal>jar</goal>
+                  </goals>
+                </execution>
+              </executions>
+            </plugin>
+            <plugin>
+              <groupId>org.apache.maven.plugins</groupId>
+              <artifactId>maven-gpg-plugin</artifactId>
+              <version>1.5</version>
+              <executions>
+                <execution>
+                  <id>sign-artifacts</id>
+                  <phase>install</phase>
+                  <goals>
+                    <goal>sign</goal>
+                  </goals>
+                </execution>
+              </executions>
+            </plugin>
+          </plugins>
+        </pluginManagement>
+
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-gpg-plugin</artifactId>
+            <version>1.5</version>
+            <executions>
+              <execution>
+                <id>sign-artifacts</id>
+                <phase>install</phase>
+                <goals>
+                  <goal>sign</goal>
+                </goals>
+              </execution>
+            </executions>
+            <inherited>false</inherited>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+  </profiles>
+
   <build>
     <pluginManagement>
       <plugins>
-        <plugin>
-          <groupId>org.sonatype.plugins</groupId>
-          <artifactId>nexus-staging-maven-plugin</artifactId>
-          <version>1.6.7</version>
-          <extensions>true</extensions>
-          <configuration>
-            <serverId>ossrh</serverId>
-            <nexusUrl>https://oss.sonatype.org/</nexusUrl>
-            <autoReleaseAfterClose>true</autoReleaseAfterClose>
-          </configuration>
-        </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-shade-plugin</artifactId>
@@ -133,19 +211,6 @@
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
-          <artifactId>maven-source-plugin</artifactId>
-          <version>2.2.1</version>
-          <executions>
-            <execution>
-              <id>attach-sources</id>
-              <goals>
-                <goal>jar-no-fork</goal>
-              </goals>
-            </execution>
-          </executions>
-        </plugin>
-        <plugin>
-          <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-javadoc-plugin</artifactId>
           <version>2.9.1</version>
           <executions>
@@ -173,23 +238,7 @@
         </plugin>
       </plugins>
     </pluginManagement>
-    <plugins>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-gpg-plugin</artifactId>
-        <version>1.5</version>
-        <executions>
-          <execution>
-            <id>sign-artifacts</id>
-            <phase>install</phase>
-            <goals>
-              <goal>sign</goal>
-            </goals>
-          </execution>
-        </executions>
-        <inherited>false</inherited>
-      </plugin>
-    </plugins>
+
   </build>
 
 </project>

--- a/testing-module/pom.xml
+++ b/testing-module/pom.xml
@@ -4,7 +4,7 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <parent>
     <artifactId>parent</artifactId>
-    <groupId>de.pxav.kelp</groupId>
+    <groupId>com.github.pxav.kelp</groupId>
     <version>0.0.3</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
@@ -16,6 +16,19 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
+        <version>3.8.1</version>
+        <configuration>
+          <source>8</source>
+          <target>8</target>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-deploy-plugin</artifactId>
+        <version>2.8.2</version>
+        <configuration>
+          <skip>true</skip>
+        </configuration>
       </plugin>
     </plugins>
   </build>
@@ -27,9 +40,9 @@
     </dependency>
 
     <dependency>
-      <groupId>de.pxav.kelp</groupId>
+      <groupId>com.github.pxav.kelp</groupId>
       <artifactId>core</artifactId>
-      <version>0.0.3-SNAPSHOT</version>
+      <version>0.0.3</version>
       <scope>provided</scope>
       <exclusions>
         <exclusion>

--- a/testing-module/pom.xml
+++ b/testing-module/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>parent</artifactId>
     <groupId>de.pxav.kelp</groupId>
-    <version>0.0.3-SNAPSHOT</version>
+    <version>0.0.3</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/v1_8_implementation/pom.xml
+++ b/v1_8_implementation/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>de.pxav.kelp</groupId>
     <artifactId>parent</artifactId>
-    <version>0.0.3-SNAPSHOT</version>
+    <version>0.0.3</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/v1_8_implementation/pom.xml
+++ b/v1_8_implementation/pom.xml
@@ -3,7 +3,7 @@
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <parent>
-    <groupId>de.pxav.kelp</groupId>
+    <groupId>com.github.pxav.kelp</groupId>
     <artifactId>parent</artifactId>
     <version>0.0.3</version>
   </parent>
@@ -23,10 +23,23 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
+        <version>3.8.1</version>
+        <configuration>
+          <source>8</source>
+          <target>8</target>
+        </configuration>
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-shade-plugin</artifactId>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-deploy-plugin</artifactId>
+        <version>2.8.2</version>
+        <configuration>
+          <skip>true</skip>
+        </configuration>
       </plugin>
     </plugins>
   </build>
@@ -72,9 +85,9 @@
     </dependency>
 
     <dependency>
-      <groupId>de.pxav.kelp</groupId>
+      <groupId>com.github.pxav.kelp</groupId>
       <artifactId>core</artifactId>
-      <version>0.0.3-SNAPSHOT</version>
+      <version>0.0.3</version>
       <scope>provided</scope>
       <exclusions>
         <exclusion>

--- a/v_1_14_implementation/pom.xml
+++ b/v_1_14_implementation/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>parent</artifactId>
     <groupId>de.pxav.kelp</groupId>
-    <version>0.0.3-SNAPSHOT</version>
+    <version>0.0.3</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/v_1_14_implementation/pom.xml
+++ b/v_1_14_implementation/pom.xml
@@ -4,7 +4,7 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <parent>
     <artifactId>parent</artifactId>
-    <groupId>de.pxav.kelp</groupId>
+    <groupId>com.github.pxav.kelp</groupId>
     <version>0.0.3</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
@@ -23,10 +23,23 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
+        <version>3.8.1</version>
+        <configuration>
+          <source>8</source>
+          <target>8</target>
+        </configuration>
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-shade-plugin</artifactId>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-deploy-plugin</artifactId>
+        <version>2.8.2</version>
+        <configuration>
+          <skip>true</skip>
+        </configuration>
       </plugin>
     </plugins>
   </build>
@@ -39,9 +52,9 @@
     </dependency>
 
     <dependency>
-      <groupId>de.pxav.kelp</groupId>
+      <groupId>com.github.pxav.kelp</groupId>
       <artifactId>core</artifactId>
-      <version>0.0.3-SNAPSHOT</version>
+      <version>0.0.3</version>
       <exclusions>
         <exclusion>
           <groupId>org.spigotmc</groupId>


### PR DESCRIPTION
This Pull Request contains the changes made to be able to publish Kelp to the Maven Central Repository:
* Adjust the parent pom file by adding `developer`, `scm`, ... attributes
* Adjust the module's pom files by configuring the deployment
* Add gpg signing, javadoc generation
* Create separate profile for deployment (called by appending `-P central-deploy`)